### PR TITLE
fixed setup install for mac osx

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,17 +105,17 @@ diagrams?  The `-l` flag (or the GUI's "long output for diagrams" option) is
 there for that!
 
     $ redeal -l -n1
-           
+
            ♠
            ♡632
            ♢AKT92
            ♣K7652
-                  
+
     ♠AJ85         ♠T962
     ♡KJ954        ♡7
     ♢QJ           ♢8763
     ♣QJ           ♣AT94
-           
+
            ♠KQ743
            ♡AQT8
            ♢54
@@ -325,3 +325,12 @@ Finally, please note that smartstacking is only available for scripts in their
 own files, not at the command line nor in the GUI.
 
 // vim: fileencoding=utf-8
+
+### NOTE* Mac OS X users zone:
+
+First reinstall gcc: brew reinstall gcc --without-multilib
+Next you have do change couple of stuff, when you clone repo with git clone --recursive git@github.com:anntzer/redeal.git you need to go and change some Makefile in dds/src (since they are not supporting .so libs on mac, it says in their README.md).
+Go to dds/src/Makefiles/Makefile_Mac_gcc:
+
+- on line 53 change STATIC_LIB = lib$(DLLBASE).a --> STATIC_LIB = lib$(DLLBASE).so
+- then on line 85 change ar rcs $(STATIC_LIB) $(O_FILES) --> g++ -dynamiclib -o $(STATIC_LIB) $(O_FILES) -v

--- a/setup.py
+++ b/setup.py
@@ -27,22 +27,20 @@ else:
 class make_build(build_py, object):
     def run(self):
         super(make_build, self).run()
-        if os.name == "posix" and not sys.platform.startswith('darwin'):
+        if os.name == "posix":
             orig_dir = os.getcwd()
             os.chdir(os.path.join(BASE_DIR, "dds", "src"))
-            subprocess.check_call(
-                ["make", "-f", "Makefiles/Makefile_linux_shared"])
+            if sys.platform.startswith('darwin'):
+                subprocess.check_call(
+                    ["make", "-f", "Makefiles/Makefile_Mac_clang"])
+                subprocess.check_call(
+                    ["make", "-f", "Makefiles/Makefile_Mac_gcc"])
+            else:
+                subprocess.check_call(
+                    ["make", "-f", "Makefiles/Makefile_linux_shared"])
             os.chdir(orig_dir)
             shutil.copy(os.path.join(BASE_DIR, "dds", "src", "libdds.so"),
                         os.path.join(self.build_lib, "redeal", "libdds.so"))
-        elif sys.platform.startswith('darwin'):
-            orig_dir = os.getcwd()
-            os.chdir(os.path.join(BASE_DIR, "dds", "src"))
-            subprocess.check_call(
-                ["make", "-f", "Makefiles/Makefile_Mac_clang"])
-            os.chdir(orig_dir)
-            shutil.copy(os.path.join(BASE_DIR, "dds", "src", "libdds.a"),
-                        os.path.join(self.build_lib, "redeal", "libdds.a"))
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,10 @@ elif os.name == "nt":
 else:
     PACKAGE_DATA = []
 
-
 class make_build(build_py, object):
     def run(self):
         super(make_build, self).run()
-        if os.name == "posix":
+        if os.name == "posix" and not sys.platform.startswith('darwin'):
             orig_dir = os.getcwd()
             os.chdir(os.path.join(BASE_DIR, "dds", "src"))
             subprocess.check_call(
@@ -36,6 +35,14 @@ class make_build(build_py, object):
             os.chdir(orig_dir)
             shutil.copy(os.path.join(BASE_DIR, "dds", "src", "libdds.so"),
                         os.path.join(self.build_lib, "redeal", "libdds.so"))
+        elif sys.platform.startswith('darwin'):
+            orig_dir = os.getcwd()
+            os.chdir(os.path.join(BASE_DIR, "dds", "src"))
+            subprocess.check_call(
+                ["make", "-f", "Makefiles/Makefile_Mac_clang"])
+            os.chdir(orig_dir)
+            shutil.copy(os.path.join(BASE_DIR, "dds", "src", "libdds.a"),
+                        os.path.join(self.build_lib, "redeal", "libdds.a"))
 
 
 setup(


### PR DESCRIPTION
There was a issue with installing redeal on mac running OS X Yosemite, its now fixed. Problem was compiling c++ code, .so libraries are not built, only .a.
