### PR TITLE
Added 7222 as a valid shape in semibalanced

### DIFF
--- a/redeal/redeal.py
+++ b/redeal/redeal.py
@@ -178,7 +178,7 @@ class Shape:
 
 
 balanced = Shape("(4333)") + Shape("(4432)") + Shape("(5332)")
-semibalanced = balanced + Shape("(5422)") + Shape("(6322)")
+semibalanced = balanced + Shape("(5422)") + Shape("(6322)") + Shape("(7222)")
 
 
 class Evaluator:


### PR DESCRIPTION
If we are allowing 6322 hands as a valid shape in "semibalanced", we might as well allow 7222 hands as well.  The alternative is to create a new type of "balanced" shape that includes 7222 hands